### PR TITLE
Add csv-file header row compatibility assertion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+#### v0.3.0
+  - add csv-file header row compatibility assertion
+    - the `LoadCache()` function now returns an error 
+      if the header row of the loaded file is does not match 
+      the current package `HEADER_ROW` variable.
+
 #### v0.2.0
   - add `width` and `height` attributes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 #### v0.3.0
   - add csv-file header row compatibility assertion
-    - the `LoadCache()` function now returns an error 
-      if the header row of the loaded file is does not match 
-      the current package `HEADER_ROW` variable.
+	- the `LoadCache()` function now returns an error
+	  if the header row of the loaded csv-file does not match
+	  the current package `HEADER_ROW` variable.
 
 #### v0.2.0
   - add `width` and `height` attributes

--- a/csvcache/csvcache.go
+++ b/csvcache/csvcache.go
@@ -6,7 +6,7 @@ import (
 	"io"
 )
 
-const Version = "v0.2.0"
+const Version = "v0.3.0"
 
 var HEADER_ROW = []string{"unique_id", "do_type", "count", "width", "height"}
 

--- a/csvcache/csvcache.go
+++ b/csvcache/csvcache.go
@@ -2,10 +2,13 @@ package csvcache
 
 import (
 	"encoding/csv"
+	"fmt"
 	"io"
 )
 
 const Version = "v0.2.0"
+
+var HEADER_ROW = []string{"unique_id", "do_type", "count", "width", "height"}
 
 type CSVCache struct {
 	modified bool
@@ -24,7 +27,7 @@ func ensureHeaderInit(csvc *CSVCache) {
 	// initialize the Header if it is empty
 	if len(csvc.Header) == 0 {
 		// add default header
-		csvc.Header = []string{"unique_id", "do_type", "count", "width", "height"}
+		csvc.Header = HEADER_ROW
 	}
 }
 
@@ -51,6 +54,17 @@ func (csvc *CSVCache) LoadCache(r io.Reader) error {
 		}
 		// skip the header record
 		if headerRow {
+			// compare header rows to make sure that they align
+			if len(record) != len(HEADER_ROW) {
+				return fmt.Errorf("incompatible csv file: input file header field count does not match current header row configuration")
+			}
+
+			for idx, value := range HEADER_ROW {
+				if value != record[idx] {
+					return fmt.Errorf("header fields do not match: idx: %d, want: '%s', got: '%s'. expecting: %v", idx, value, record[idx], HEADER_ROW)
+				}
+			}
+
 			headerRow = false
 			csvc.Header = record
 			continue

--- a/csvcache/csvcache_test.go
+++ b/csvcache/csvcache_test.go
@@ -2,11 +2,12 @@ package csvcache
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
 )
 
-const fixturePath = "./testdata/basic.csv"
-const tmpFilePath = "./testdata/tmp.csv"
+const fixtureRoot = "./testdata"
+const tmpFileRoot = "./testdata"
 
 func assertStringsEqual(want, got string, t *testing.T) {
 	if want != got {
@@ -56,7 +57,7 @@ func createAndLoadCSVCache(path string, t *testing.T) *CSVCache {
 func TestHeader(t *testing.T) {
 	var want, got string
 
-	cache := createAndLoadCSVCache(fixturePath, t)
+	cache := createAndLoadCSVCache(filepath.Join(fixtureRoot, "basic.csv"), t)
 	sut := cache.Header
 
 	want = "unique_id"
@@ -83,7 +84,7 @@ func TestHeader(t *testing.T) {
 func TestGetRecordPresent(t *testing.T) {
 	var want, got []string
 
-	sut := createAndLoadCSVCache(fixturePath, t)
+	sut := createAndLoadCSVCache(filepath.Join(fixtureRoot, "basic.csv"), t)
 
 	want = []string{"ghx3fpf7", "image_set", "2", "136", "108"}
 	got = sut.GetRecord("ghx3fpf7")
@@ -92,7 +93,7 @@ func TestGetRecordPresent(t *testing.T) {
 
 func TestGetRecordMissing(t *testing.T) {
 
-	sut := createAndLoadCSVCache(fixturePath, t)
+	sut := createAndLoadCSVCache(filepath.Join(fixtureRoot, "basic.csv"), t)
 
 	got := sut.GetRecord("this-key-does-not-have-a-record")
 	assertRecordsEqual(nil, got, t)
@@ -100,7 +101,7 @@ func TestGetRecordMissing(t *testing.T) {
 
 func TestAddRecord(t *testing.T) {
 
-	sut := createAndLoadCSVCache(fixturePath, t)
+	sut := createAndLoadCSVCache(filepath.Join(fixtureRoot, "basic.csv"), t)
 
 	got := sut.GetRecord("9ec2c7f5d0c4")
 	assertRecordsEqual(nil, got, t)
@@ -116,7 +117,7 @@ func TestAddRecord(t *testing.T) {
 
 func TestIsModified(t *testing.T) {
 
-	sut := createAndLoadCSVCache(fixturePath, t)
+	sut := createAndLoadCSVCache(filepath.Join(fixtureRoot, "basic.csv"), t)
 
 	got := sut.GetRecord("9ec2c7f5d0c4")
 	assertRecordsEqual(nil, got, t)
@@ -146,7 +147,7 @@ func TestAddRecordToCSVCThatWasNotLoadedFromFile(t *testing.T) {
 
 func TestWriteCache(t *testing.T) {
 
-	sut1 := createAndLoadCSVCache(fixturePath, t)
+	sut1 := createAndLoadCSVCache(filepath.Join(fixtureRoot, "basic.csv"), t)
 
 	// assert baseline
 	got := sut1.GetRecord("9ec2c7f5d0c4")
@@ -164,19 +165,19 @@ func TestWriteCache(t *testing.T) {
 	assertRecordsEqual(want, got, t)
 
 	// open the target file
-	w, err := os.Create(tmpFilePath)
+	w, err := os.Create(filepath.Join(tmpFileRoot, "tmp-basic.csv"))
 	if err != nil {
-		t.Errorf("problem creating %s", tmpFilePath)
+		t.Errorf("problem creating %s", filepath.Join(tmpFileRoot, "tmp-basic.csv"))
 	}
 	defer w.Close()
 
 	// write the target file
 	err = sut1.WriteCache(w)
 	if err != nil {
-		t.Errorf("problem writing %s", tmpFilePath)
+		t.Errorf("problem writing %s", filepath.Join(tmpFileRoot, "tmp-basic.csv"))
 	}
 
-	sut2 := createAndLoadCSVCache(tmpFilePath, t)
+	sut2 := createAndLoadCSVCache(filepath.Join(tmpFileRoot, "tmp-basic.csv"), t)
 
 	assertRecordsEqual(sut1.Header, sut2.Header, t)
 	assertRecordsEqual(sut1.GetRecord("m63xss7g"), sut2.GetRecord("m63xss7g"), t)
@@ -186,9 +187,9 @@ func TestWriteCache(t *testing.T) {
 	assertRecordsEqual(sut1.GetRecord("9ec2c7f5d0c4"), sut2.GetRecord("9ec2c7f5d0c4"), t)
 
 	// cleanup
-	err = os.Remove(tmpFilePath)
+	err = os.Remove(filepath.Join(tmpFileRoot, "tmp-basic.csv"))
 	if err != nil {
-		t.Errorf("problem removing %s", tmpFilePath)
+		t.Errorf("problem removing %s", filepath.Join(tmpFileRoot, "tmp-basic.csv"))
 	}
 }
 
@@ -200,3 +201,13 @@ func TestHeaderInitialized(t *testing.T) {
 	got := sut.Header
 	assertRecordsEqual(want, got, t)
 }
+
+/* func TestIncompatibleFile(t *testing.T) {
+
+	sut := NewCSVCache()
+
+	want := []string{"unique_id", "do_type", "count", "width", "height"}
+	got := sut.Header
+	assertRecordsEqual(want, got, t)
+}
+*/

--- a/csvcache/csvcache_test.go
+++ b/csvcache/csvcache_test.go
@@ -202,12 +202,50 @@ func TestHeaderInitialized(t *testing.T) {
 	assertRecordsEqual(want, got, t)
 }
 
-/* func TestIncompatibleFile(t *testing.T) {
+func TestIncompatibleFileTooFewColumns(t *testing.T) {
 
-	sut := NewCSVCache()
+	path := filepath.Join(fixtureRoot, "too-few-columns.csv")
+	c := NewCSVCache()
 
-	want := []string{"unique_id", "do_type", "count", "width", "height"}
-	got := sut.Header
-	assertRecordsEqual(want, got, t)
+	r, err := os.Open(path)
+	if err != nil {
+		t.Errorf("problem opening %s", path)
+	}
+	defer r.Close()
+
+	err = c.LoadCache(r)
+	if err == nil {
+		t.Errorf("expected LoadCache() to return an error, but no error returned.")
+		return
+	}
+
+	want := "incompatible csv file: input file header field count does not match current header row configuration"
+	got := err.Error()
+	if want != got {
+		t.Errorf("expected error message to be '%s', but got '%s'", want, got)
+	}
 }
-*/
+
+func TestIncompatibleFileHeaderColumnMismatch(t *testing.T) {
+
+	path := filepath.Join(fixtureRoot, "mismatched-header-columns.csv")
+	c := NewCSVCache()
+
+	r, err := os.Open(path)
+	if err != nil {
+		t.Errorf("problem opening %s", path)
+	}
+	defer r.Close()
+
+	err = c.LoadCache(r)
+	if err == nil {
+		t.Errorf("expected LoadCache() to return an error, but no error returned.")
+		return
+	}
+
+	want := "header fields do not match: idx: 0, want: 'unique_id', got: 'foo'. expecting: [unique_id do_type count width height]"
+	got := err.Error()
+	if want != got {
+		t.Errorf("expected error message to be '%s', but got '%s'", want, got)
+	}
+}

--- a/csvcache/testdata/mismatched-header-columns.csv
+++ b/csvcache/testdata/mismatched-header-columns.csv
@@ -1,0 +1,5 @@
+foo,bar,baz,quux,height
+m63xss7g,image_set,6,201,272
+ghx3fpf7,image_set,2,136,108
+zkh18f2c,image,1,156,154
+xgxd28gq,image_set,32,176,174

--- a/csvcache/testdata/too-few-columns.csv
+++ b/csvcache/testdata/too-few-columns.csv
@@ -1,0 +1,5 @@
+unique_id,do_type,count
+m63xss7g,image_set,6
+ghx3fpf7,image_set,2
+zkh18f2c,image,1
+xgxd28gq,image_set,32


### PR DESCRIPTION
# Overview
## v0.3.0
  - add csv-file header row compatibility assertion
    - the `LoadCache()` function now returns an error 
      if the header row of the loaded csv-file does not match 
      the current package `HEADER_ROW` variable.
